### PR TITLE
Feature: add bundle to framework

### DIFF
--- a/Sources/ScipioKit/Helpers/Xcode.swift
+++ b/Sources/ScipioKit/Helpers/Xcode.swift
@@ -105,7 +105,25 @@ struct Xcode {
                 try command.run()
             }
 
+            // Framework bundles should be added manually:
+            // https://forums.swift.org/t/swift-packages-resource-bundle-not-present-in-xcarchive-when-framework-using-said-package-is-archived/50084/4
+            includeBundle(productName: productName, archivePaths: archivePaths, outputPath: output)
+
             return output
+        }
+    }
+
+    private static func includeBundle(productName: String, archivePaths: [Path], outputPath: Path) {
+        let bundleName = "\(productName)_\(productName).bundle"
+        let bundles = archivePaths.map { $0 + "Products/Library/Frameworks/\(bundleName)" }
+        let outputFrameworks = outputPath.glob("*/\(productName).framework")
+
+        guard bundles.count == outputFrameworks.count,
+              bundles.allSatisfy({ $0.exists }) else { return }
+
+        log.info("Including \(bundleName)...")
+        outputFrameworks.enumerated().forEach { index, path in
+            try? bundles[index].copy(path + bundleName)
         }
     }
 }

--- a/Sources/ScipioKit/Helpers/Xcode.swift
+++ b/Sources/ScipioKit/Helpers/Xcode.swift
@@ -105,7 +105,7 @@ struct Xcode {
                 try command.run()
             }
 
-            // Framework bundles should be added manually:
+            // TODO: By now, framework bundles should be added manually
             // https://forums.swift.org/t/swift-packages-resource-bundle-not-present-in-xcarchive-when-framework-using-said-package-is-archived/50084/4
             includeBundle(productName: productName, archivePaths: archivePaths, outputPath: output)
 


### PR DESCRIPTION
When creating a `xcframework`, we have to copy the bundles (if exists) to the correct destination.
It's a known issue described here:
https://forums.swift.org/t/swift-packages-resource-bundle-not-present-in-xcarchive-when-framework-using-said-package-is-archived/50084/4