### PR TITLE
Feature: include DSYMs when creating the frameworks

### DIFF
--- a/Sources/ScipioKit/Helpers/Xcode.swift
+++ b/Sources/ScipioKit/Helpers/Xcode.swift
@@ -87,8 +87,8 @@ struct Xcode {
             // The following snippet of code is used to solve issue: https://github.com/apple/swift/issues/56573
             // But the solution is fragile
             try frameworks.forEach { framework in
-                    let frameworkName = framework.path.lastComponentWithoutExtension
-                    let swiftInterfaces = (framework.path + "Modules/\(frameworkName).swiftmodule").glob("*.swiftinterface")
+                let frameworkName = framework.path.lastComponentWithoutExtension
+                let swiftInterfaces = (framework.path + "Modules/\(frameworkName).swiftmodule").glob("*.swiftinterface")
                 try swiftInterfaces.forEach { interface in
                     let content = try interface.read(.utf8)
                     var replaced = content


### PR DESCRIPTION
When creating the framework from `xcode-build`, add the additional argument for the dsym path to be included on the final framework.